### PR TITLE
Umgestellt auf 'includeCurrentPageSubPath'

### DIFF
--- a/pages/index.php
+++ b/pages/index.php
@@ -1,14 +1,3 @@
 <?php
-
-// Die layout/top.php und layout/bottom.php werden automatisch eingebunden
-
-// Die Subpages müssen dem Titel nicht mehr übergeben werden
-echo rex_view::title('Backend Branding'); // $this->i18n('title') ist eine Kurzform für rex_i18n::msg('be_branding_title')
-
-// Die Subpages werden nicht mehr über den "subpage"-Parameter gesteuert, sondern über "page" (getrennt mit einem Slash, z. B. page=be_branding/config)
-// Die einzelnen Teile des page-Pfades können mit der folgenden Funktion ausgelesen werden.
-//$subpage = rex_be_controller::getCurrentPagePart(1);
-
-// Subpages können über diese Methode eingebunden werden. So ist sichergestellt, dass auch Subpages funktionieren,
-// die von anderen Addons/Plugins hinzugefügt wurden
-include rex_be_controller::getCurrentPageObject()->getSubPath();
+echo rex_view::title('Backend Branding'); 
+rex_be_controller::includeCurrentPageSubPath();


### PR DESCRIPTION
von: @christophboecker

Ziel des PR: Umstellung auf aktuelle rex-Methoden und einheitliche Vorgehensweise
in möglichst allen AddOns.

Es gibt eine alte und eine aktuelle Methode, die
Sub-Pages einzubinden. Die neue Methode ist seit REDAXO 5.1 verfügbar.

Die alte Methode funktioniert weiterhin, sollte aber wegen verbesserter Interoperabilität
zwischen AddOns auf die neue Version umgestellt werden (Hinweis von gharlan).
In den Core-Addons ist das bereits geschehen, desgleichen bei einige FOR- und Y-Addons.
Bezogen auf das Addon selbst sind beide Varianten derzeit gleichwertig. Die neue Methode
erlaubt z.B. eine verbesserte Einbindung von Pages aus anderen Addons, die dann im
Context des Quell-Addons laufen und nicht des Ziel-Addons.

Betroffen waren rund 40 AddOns (FOR/Y), konkret deren Script pages/index.php, das
wie folgt geändert werden sollte:

Alt:
echo rex_view::title(.....);
include rex_be_controller::getCurrentPageObject()->getSubPath();

ab REDAXO 5.1:
echo rex_view::title(.....);
rex_be_controller::includeCurrentPageSubPath();